### PR TITLE
SimpleController: fix sending commands without having any input samples

### DIFF
--- a/skid4_control.orogen
+++ b/skid4_control.orogen
@@ -37,7 +37,7 @@ task_context "SimpleController" do
     property("left_wheel_names", "std::vector<std::string>")
     property("right_wheel_names", "std::vector<std::string>")
 
-    input_port('motion_command', 'base/MotionCommand2D').
+    input_port('motion_command', 'base/commands/Motion2D').
         doc('input command in rotation and translation. Requires a data connection type.')
 end
 
@@ -51,7 +51,7 @@ task_context "ConstantSpeedController" do
     property("speed", "double", 0.0).
         doc("speed that is applied to the motors")
 
-    input_port('motion_command', 'base/MotionCommand2D').
+    input_port('motion_command', 'base/commands/Motion2D').
         doc('input command in rotation and translation. Requires a data connection type.')
 end
 
@@ -78,7 +78,7 @@ task_context "SoftTurnController" do
     property("Tt", "double", -1.0)
 
 
-    input_port('motion_command', 'base/MotionCommand2D').
+    input_port('motion_command', 'base/commands/Motion2D').
         doc('input command in rotation and translation. Requires a data connection type.')
 end
 

--- a/skid4_control.orogen
+++ b/skid4_control.orogen
@@ -26,6 +26,9 @@ task_context "SimpleController" do
 
     needs_configuration
 
+    property("timeout", "double",0.1).
+        doc("Timeout in seconds after a stop command is emitted if no new motion commands are available.")
+
     property("wheel_radius", "double").
         doc("the radius of a wheel, in meters")
     property("track_width", "double").

--- a/tasks/SimpleController.cpp
+++ b/tasks/SimpleController.cpp
@@ -49,7 +49,9 @@ bool SimpleController::configureHook()
         m_rightIndexes.push_back(curIndex);
         curIndex++;        
     }
-    
+
+    // The output of this controller is a speed command.
+    m_cmd.mode[0] = m_cmd.mode[1] = m_cmd.mode[2] = m_cmd.mode[3] = base::actuators::DM_SPEED;
     return true;    
 }
 
@@ -64,10 +66,6 @@ void SimpleController::updateHook()
         cmd_in.translation = 0;
         cmd_in.rotation    = 0;
     }
-
-    // The output of this controller is a speed command.
-    m_cmd.mode[0] = m_cmd.mode[1] =
-        m_cmd.mode[2] = m_cmd.mode[3] = base::actuators::DM_SPEED;
 
     double fwd_velocity = cmd_in.translation / m_radius;
     double differential = cmd_in.rotation * m_trackWidth / m_radius;


### PR DESCRIPTION
If a data connection to the input port exists the controller sends old
data as new commands even if no new input samples are available. This
results in a dangerous behaviour commanding the robot to move without
any timeout.

The new implementation repeats the command until a timeout
interval passed. After this, stop commands are sent until a new
input sample arrived. This ensures that if the commanding component
freezes or forgets to send a stop command the robot stops after n
seconds.
