### PR TITLE
Differential speed depends on track radius not track width

### DIFF
--- a/tasks/SimpleController.cpp
+++ b/tasks/SimpleController.cpp
@@ -24,9 +24,9 @@ bool SimpleController::configureHook()
         return false;
 
     m_radius = _wheel_radius.get();
-    m_trackWidth = _track_width.get();
+    m_trackRadius = _track_width.get() / 2;
     m_cmd_timeout = base::Timeout(_cmd_timeout.value());
-    if (m_radius <= 0 || m_trackWidth <= 0)
+    if (m_radius <= 0 || m_trackRadius <= 0)
     {
         RTT::log(RTT::Error) << "wrong radius and/or track_width parameters" << RTT::endlog();
         return false;
@@ -53,7 +53,7 @@ void SimpleController::updateHook()
         return;
 
     double fwd_velocity = cmd_in.translation / m_radius;
-    double differential = cmd_in.rotation * m_trackWidth / m_radius;
+    double differential = cmd_in.rotation * m_trackRadius / m_radius;
 
     for(std::vector<size_t>::const_iterator it = m_leftIndexes.begin(); it != m_leftIndexes.end();it++)
     {

--- a/tasks/SimpleController.hpp
+++ b/tasks/SimpleController.hpp
@@ -13,7 +13,7 @@ namespace skid4_control {
 	friend class SimpleControllerBase;
 
         double m_radius;
-        double m_trackWidth;
+        double m_trackRadius;
         base::Timeout m_cmd_timeout;
 
     public:


### PR DESCRIPTION
To visualize why this is "more correct", imagine a robot with one axis wanting to turn around its center point. The wheels just have to run a circle with a radius of half the robot's width.

Obviously, this change would change the behavior of existing configurations ...